### PR TITLE
Update class-cocart-products-controller.php

### DIFF
--- a/includes/api/cocart/v2/products/class-cocart-products-controller.php
+++ b/includes/api/cocart/v2/products/class-cocart-products-controller.php
@@ -219,6 +219,7 @@ class CoCart_Products_V2_Controller extends CoCart_Products_Controller {
 		$variation_ids    = $product->get_children();
 		$tax_display_mode = $this->get_tax_display_mode();
 		$price_function   = $this->get_price_from_tax_display_mode( $tax_display_mode );
+		$variations = array();
 
 		foreach ( $variation_ids as $variation_id ) {
 			$variation = wc_get_product( $variation_id );


### PR DESCRIPTION
#1 fixed php error: `Undefined variable: variations in <b>/plugins/cart-rest-api-for-woocommerce/includes/api/cocart/v2/products/class-cocart-products-controller.php</b> on line <b>276</b>` => array was not properly initialized.

### Description
added $variations = array(); to line 222 to init the array later used in line 246 ($variations[] = array(... )

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
i had an issue with this and now the issue is gone..